### PR TITLE
Replace exit/die by Exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "melipayamak/php",
     "type": "library",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A PHP wrapper for melipayamak's web services",
     "keywords": ["melipayamak", "sms", "api"],
     "homepage": "http://github.com/Melipayamak/melipayamak-php",

--- a/src/Branch.php
+++ b/src/Branch.php
@@ -20,9 +20,7 @@ class Branch
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		

--- a/src/BranchAsync.php
+++ b/src/BranchAsync.php
@@ -20,9 +20,7 @@ class BranchAsync
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		

--- a/src/Contacts.php
+++ b/src/Contacts.php
@@ -20,9 +20,7 @@ class Contacts
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		

--- a/src/ContactsAsync.php
+++ b/src/ContactsAsync.php
@@ -20,9 +20,7 @@ class ContactsAsync
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		

--- a/src/MelipayamakApi.php
+++ b/src/MelipayamakApi.php
@@ -18,9 +18,7 @@ class MelipayamakApi
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		
@@ -60,7 +58,8 @@ class MelipayamakApi
 
 		if(class_exists($class))
 			return new $class($this->username,$this->password);
-					
+
+		throw new RuntimeException("Class {$class} not found");
 	}
 	
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -20,9 +20,7 @@ class Ticket
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		

--- a/src/TicketAsync.php
+++ b/src/TicketAsync.php
@@ -20,9 +20,7 @@ class TicketAsync
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		

--- a/src/Users.php
+++ b/src/Users.php
@@ -20,9 +20,7 @@ class Users
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		

--- a/src/UsersAsync.php
+++ b/src/UsersAsync.php
@@ -20,9 +20,7 @@ class UsersAsync
 		
 		if (is_null($username)||is_null($password)) {
 			
-			die('username/password is empty');
-			
-			exit;
+			throw new RuntimeException('username/password is empty');
 			
 		}
 		


### PR DESCRIPTION
Replace `exit`/`die` by `throw new RuntimeException`. 

By throwing Exception we can terminate process like Exit, **plus** developers could be able to **catch and handle errors** across their applications.

[This is also best practice to handle errors in libraries.](http://javierferrer.me/exceptions-vs-error-codes/)